### PR TITLE
Added an example job and python script to be used on flemish HPC infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
-*demo available (src/SEIRSAgeModel_demo.ipynb)*
-
-# Biomath COVID19-Model
-
+# BIOMATH COVID19-Model
 *Original code by Ryan S. McGee. Modified by T.W. Alleman in consultation with the BIOMATH research unit headed by prof. Ingmar Nopens.*
 
-Copyright (c) 2020 by T.W. Alleman, BIOMATH, Ghent University. All Rights Reserved.
+Copyright (c) 2020 by T.W. Alleman, BIOMATH, Ghent University.
 
-Our code implements a SEIRS infectious disease dynamics models with extensions to model the effect quarantining detected cases. UOur code allows to quickly perform Monte Carlo simulations, calibrate model parameters and calculate an *optimal* government policies using a model predictive controller (MPC). A white paper and souce code of our previous work can be found on the Biomath website. 
+Our code implements a SEIRS infectious disease dynamics models with extensions to model the effect quarantining detected cases. Our code allows to quickly perform Monte Carlo simulations, calibrate model parameters and calculate an *optimal* government policies using a model predictive controller (MPC). A white paper and souce code of our previous work can be found on the [BIOMATH website](https://biomath.ugent.be/covid-19-outbreak-modelling-and-control). 
 
-https://biomath.ugent.be/covid-19-outbreak-modelling-and-control
+
+## Demo
+A demo of the model can be found [here](src/SEIRSAgeModel_demo.ipynb). This notebook can also be run in the browser through binder,
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/UGentBiomath/COVID19-Model/master?filepath=src%2FSEIRSAgeModel_demo.ipynb)
+
 
 ## Model highlights
 
@@ -26,19 +28,13 @@ As of now (20/04/2020), the *SEIRSAgeModel* (deterministic model implementation 
 
 As of now (20/04/2020), the *SEIRSNetworkModel* contains 5 functions which can be grouped in two parts: 1) functions to run and visualise simulations and 2) functions to perform parameter estimations and visualse the results. Implementing the model predictive controller is straightforward and can easily be done. However, the optimisation problem is really difficult and requires thousands of function evaluations. Given the large amount of computational resources required to run just one stochastic simulation, it is highly unlikely that the model predictive controller will ever be used to optimize government policy. The MPC functions will be implemented and their usefullness assessed after a calibration is performed. Also, scenario specific functions will be added over the course of next week. 
 
-<img src="figs/SEIRSNetworkModel.jpg"
-     alt="class"
-     width="700"     
-     style="float: left; margin-right: 500px;" /> 
 
 ## How to use the model
-
 A Jupyter Notebooks containing all scientific details and a tutorial of both frameworks is available in the /src folder.
 
 ## Future work
 
 ### Model dynamics
-
 Future work will include a modification of the model dynamics most likely according to the flowchart below, this will be done in collaboration with hospitals. We believe these will allow to simulate the disease spread even more realisticly.
 
 <img src="figs/flowchart3_1.jpg" alt="drawing" width="800"/>

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,14 @@
+name: COVID_MODEL
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  - ipython
+  - jupyter
+  - notebook
+  - matplotlib>3
+  - numpy
+  - scipy
+  - networkx
+  - pandas
+  - ipywidgets

--- a/hpc/HPC_README.md
+++ b/hpc/HPC_README.md
@@ -1,0 +1,33 @@
+# Biomath COVID19-Model: HPC
+
+*Original code by Ryan S. McGee. Modified by T.W. Alleman in consultation with the BIOMATH research unit headed by prof. Ingmar Nopens.*
+
+Copyright (c) 2020 by T.W. Alleman, BIOMATH, Ghent University. All Rights Reserved.
+
+Our code implements a SEIRS infectious disease dynamics models with extensions to model the effect quarantining detected cases and back tracking. To this end, the SEIR dynamics are implemented using two frameworks: 1) deterministic framework and 2) stochastic network framework. Our code allows to quickly perform Monte Carlo simulations, calibrate model parameters and calculate an *optimal* government policies using a model predictive controller (MPC). The stochastic model is computationally heavy and is preferentially computed using the Flemish high performance computing infrastructure.
+
+## Prerequisites
+
+Configuring pip to install the necessary packages when first using Python on (Flemish) HPC:
+
+1. $ module load Python/3.6.6-intel-2018b
+2. $ mkdir -p "${VSC_DATA}/python_lib/lib/python3.6/site-packages/"
+3. $ export PYTHONPATH="${VSC_DATA}/python_lib/lib/python3.7/site-packages/:${PYTHONPATH}"
+4. open bashrc using $vi ~/.bashrc and insert the following line: 
+$ export PYTHONPATH="${VSC_DATA}/python_lib/lib/python3.7/site-packages/:${PYTHONPATH}"
+5. $ pip install --install-option="--prefix=${VSC_DATA}/python_lib" matplotlib
+6. Install packages *seaborn* and *networkx* by modifying the above command.
+
+https://vlaams-supercomputing-centrum-vscdocumentation.readthedocs-hosted.com/en/latest/software/python_package_management.html?highlight=conda#install-an-additional-package
+
+## Computing Time for stochastic model
+
+Results shown below were obtained by executing *sim_stochastic.py* on a single core of the *victini* cluster (Intel Xeon Gold 6140 @ 2.3 GHz).
+
+## Usefull commands
+
+Copy from HPC to Linux PC:
+scp vscxxxx@login.hpc.ugent.be:/user/gent/xxx/vscxxxxx/Documents/COVID-19/test.sh .
+
+Copy from Linux PC to HPC:
+scp sim_stochastic.py test.sh vscxxxxx@login.hpc.ugent.be:/user/gent/xxx/vscxxxxx/Documents/COVID-19/

--- a/hpc/sim_stochastic.py
+++ b/hpc/sim_stochastic.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# Load required packages
+#~~~~~~~~~~~~~~~~~~~~~~~
+import numpy as np
+import matplotlib.pyplot as plt
+import pandas as pd
+import datetime
+import scipy
+from scipy.integrate import odeint
+import matplotlib.dates as mdates
+import matplotlib
+import scipy.stats as st
+import networkx
+import timeit
+
+# Import in-house code from /src directory
+# First Python must be told where to find models.py
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import sys, os
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src'))
+import models
+
+# Construct the network G
+# ~~~~~~~~~~~~~~~~~~~~~~~
+numNodes = 120000
+baseGraph    = networkx.barabasi_albert_graph(n=numNodes, m=7)
+# Baseline normal interactions:
+G_norm     = models.custom_exponential_graph(baseGraph, scale=200)
+models.plot_degree_distn(G_norm, max_degree=40)
+
+# Construct the network G under social distancing
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+numNodes = 120000
+baseGraph    = networkx.barabasi_albert_graph(n=numNodes, m=2)
+# Baseline normal interactions:
+G_dist     = models.custom_exponential_graph(baseGraph, scale=20000)
+models.plot_degree_distn(G_dist, max_degree=40)
+
+# Define model
+# ~~~~~~~~~~~~
+model = models.SEIRSNetworkModel(
+                                 # network connectivty
+                                 G = G_norm,
+                                 p       = 0.6,
+                                 # clinical parameters
+                                 beta    = 0.3, 
+                                 sigma   = 5.2,
+                                 zeta    = 0,
+                                 sm      = 0.50,
+                                 m       = (1-0.50)*0.81,
+                                 h       = (1-0.50)*0.15,
+                                 c       = (1-0.50)*0.04,
+                                 dsm     = 14,
+                                 dm      = 14,
+                                 dhospital = 1,
+                                 dh      = 21,
+                                 dcf     = 18.5,
+                                 dcr     = 22.0,
+                                 mc0     = 0.49,
+                                 ICU     = 2000,
+                                 # testing
+                                 theta_S = 0,
+                                 theta_E = 0,
+                                 theta_SM= 0,
+                                 theta_M = 0,
+                                 theta_R = 0,
+                                 psi_FP = 0,
+                                 psi_PP = 1,
+                                 dq     = 14,                                 
+                                 # back-tracking
+                                 phi_S   = 0,
+                                 phi_E   = 0,
+                                 phi_SM  = 0,
+                                 phi_R   = 0,
+                                 # initial condition
+                                 initN = 11.43e6, #results are extrapolated to entire population
+                                 initE = 100,
+                                 initSM = 0, 
+                                 initM = 0,
+                                 initH = 0,
+                                 initC = 0,
+                                 initHH = 0,
+                                 initCH = 0,
+                                 initR = 0,
+                                 initF = 0,
+                                 initSQ = 0,
+                                 initEQ = 0,
+                                 initSMQ = 0,
+                                 initMQ = 0,
+                                 initRQ = 0
+                            )
+
+# Create checkpoints dictionary
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+chk = {'t':       [40,80], 
+       'G':       [G_dist,G_norm],
+       'p':       [0.01,0.6],
+      }
+
+# Run simulation and time
+# ~~~~~~~~~~~~~~~~~~~~~~~
+start = timeit.default_timer()
+model.sim(T=100,checkpoints=chk)
+stop = timeit.default_timer()
+print('Required time: ', stop - start,' seconds')
+
+# Make a graphical representation of results
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+model.plotPopulationStatus(filename='populationStatus.svg')
+model.plotInfected(filename='infected.svg')

--- a/hpc/test.sh
+++ b/hpc/test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#PBS -N python_test ## job name
+#PBS -l nodes=1:ppn=1 ## single-node job, single core
+#PBS -l walltime=1:00:00 ## max. 2h of wall time
+
+# load python module
+module load Python/3.6.6-intel-2018b
+
+# Change to package folder
+cd $VSC_HOME/Documents/COVID-19/hpc/
+
+# Make script executable
+chmod +x sim_stochastic.py
+
+# Execute script
+python sim_stochastic.py
+
+
+


### PR DESCRIPTION
A little documentation on installing the necessary packages upon first use of Python on HPC is provided as well in the HPC_readme. A graph with single-core computation times as a function of the number of nodes in the stochastic network model will be added soon.