### PR TITLE
Add binder link to each PR

### DIFF
--- a/.github/workflows/binder.yml
+++ b/.github/workflows/binder.yml
@@ -1,0 +1,30 @@
+name: Binder
+on: 
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  Create-Binder-Badge:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: checkout pull request branch
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: comment on PR with Binder link
+      uses: actions/github-script@v1
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          var BRANCH_NAME = process.env.BRANCH_NAME;
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: `[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/${context.repo.owner}/${context.repo.repo}/${BRANCH_NAME}) :point_left: Launch a binder notebook on this branch`
+          }) 
+      env:
+        BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
+


### PR DESCRIPTION
After seeing https://gist.github.com/hamelsmu/f8f98e0fa18852c576973051d3cf72b1 I thought this could be useful for the covid modelling case.

<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [] I made sure all new and existing data sets have a description in the `data/README.md` file
* [ ] I have updated the documentation accordingly.

I bumped into this [github workflow](https://gist.github.com/hamelsmu/f8f98e0fa18852c576973051d3cf72b1) providing a binder link for each branch when a PR is done. I thought this could be useful for the covid modelling case... 

@Beramos @JennaVergeynst  see if this would make sense.
