### PR TITLE
Add pip to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
   - defaults
   - conda-forge
 dependencies:
+  - pip
   - ipython
   - jupyter
   - notebook


### PR DESCRIPTION
This is needed to be able to do `pip install -e .` afterwards (I think conda stopped including it automatically, or it might depend on your settings. So including it explicitly should be good anyway)