### PR TITLE
Fix model without stratification + update tests + fix time_dependent_parameter validation

### DIFF
--- a/src/covid19model/models/base.py
+++ b/src/covid19model/models/base.py
@@ -44,16 +44,16 @@ class BaseModel:
         self.discrete = discrete
 
         if self.stratification:
-            self.stratification_size=[]
+            self.stratification_size = []
             for axis in self.stratification:
                 if not axis in parameters:
                     raise ValueError(
                         "stratification parameter '{0}' is missing from the specified "
-                        "parameters dictionary".format(self.stratification)
+                        "parameters dictionary".format(axis)
                     )
                 self.stratification_size.append(parameters[axis].shape[0])
         else:
-            self.stratification_size = 1
+            self.stratification_size = [1]
 
         if time_dependent_parameters:
             self._validate_time_dependent_parameters()
@@ -87,10 +87,12 @@ class BaseModel:
 
         extra_params = []
 
+        all_param_names = self.parameter_names + self.parameters_stratified_names
+        if self.stratification:
+            all_param_names.extend(self.stratification)
+
         for param, func in self.time_dependent_parameters.items():
-            if (param not in (
-                self.parameter_names + self.parameters_stratified_names + [self.stratification])
-            ):
+            if param not in all_param_names:
                 raise ValueError(
                     "The specified time-dependent parameter '{0}' is not an "
                     "existing model parameter".format(param))
@@ -133,7 +135,7 @@ class BaseModel:
 
         integrate_params = keywords[1 + N_states :]
         specified_params = self.parameter_names.copy()
-        
+
         if self.parameters_stratified_names:
             for stratified_names in self.parameters_stratified_names:
                 if stratified_names:
@@ -224,7 +226,7 @@ class BaseModel:
             else:
                 # otherwise add default of 0
                 self.initial_states[state] = np.zeros(self.stratification_size)
-        
+
         # validate the states (using `set` to ignore order)
         if set(self.initial_states.keys()) != set(self.state_names):
             raise ValueError(
@@ -414,23 +416,28 @@ class BaseModel:
         """
         Convert array (returned by scipy) to an xarray Dataset with variable names
         """
-        dims=self.stratification.copy()
+
+        if self.stratification:
+            dims = self.stratification.copy()
+        else:
+            dims = []
         dims.append('time')
 
         coords = {
             "time": output["t"],
         }
 
-        for i in range(len(self.stratification)):
-            if self.coordinates and self.coordinates[i] is not None:
-                coords.update({self.stratification[i]: self.coordinates[i]})
-            else:
-                coords.update({self.stratification[i]: np.arange(self.stratification_size[i])})
+        if self.stratification:
+            for i in range(len(self.stratification)):
+                if self.coordinates and self.coordinates[i] is not None:
+                    coords.update({self.stratification[i]: self.coordinates[i]})
+                else:
+                    coords.update({self.stratification[i]: np.arange(self.stratification_size[i])})
 
-
-        size_lst=[len(self.state_names)]
-        for size in self.stratification_size:
-            size_lst.append(size)
+        size_lst = [len(self.state_names)]
+        if self.stratification:
+            for size in self.stratification_size:
+                size_lst.append(size)
         size_lst.append(len(output["t"]))
         y_reshaped = output["y"].reshape(tuple(size_lst))
 

--- a/src/tests/test_model.py
+++ b/src/tests/test_model.py
@@ -89,8 +89,8 @@ class SIRstratified(BaseModel):
     # state variables and parameters
     state_names = ['S', 'I', 'R']
     parameter_names = ['gamma']
-    parameters_stratified_names = ['beta']
-    stratification = 'nc'
+    parameters_stratified_names = [['beta']]
+    stratification = ['nc']
 
     @staticmethod
     def integrate(t, S, I, R, gamma, beta, nc):
@@ -117,7 +117,7 @@ def test_model_stratified_simple_sir():
 
     np.testing.assert_allclose(output["time"], np.arange(0, 51))
     np.testing.assert_allclose(
-        output.coords['stratification'].values, np.array([0, 1])
+        output.coords['nc'].values, np.array([0, 1])
     )
 
 
@@ -133,8 +133,8 @@ def test_model_stratified_init_validation():
     # model state/parameter names didn't change
     assert model.state_names == ['S', 'I', 'R']
     assert model.parameter_names == ['gamma']
-    assert model.parameters_stratified_names == ['beta']
-    assert model.stratification == 'nc'
+    assert model.parameters_stratified_names == [['beta']]
+    assert model.stratification == ['nc']
 
     # wrong initial states
     initial_states2 = {"S": [1_000_000 - 10]*2, "II": [10]*2}
@@ -163,12 +163,12 @@ def test_model_stratified_init_validation():
 
     # initial state of the wrong length
     initial_states2 = {"S": 600_000 - 20, "I": [20, 10], "R": [0, 0]}
-    msg = "A initial state value should be a 1D array"
+    msg = r"The stratification parameters '\['nc'\]' indicates a stratification size of \[2\], but"
     with pytest.raises(ValueError, match=msg):
         SIRstratified(initial_states2, parameters)
 
     initial_states2 = {"S": [0] * 3, "I": [20, 10], "R": [0, 0]}
-    msg = "The stratification parameter 'nc' indicates a stratification size of 2, but"
+    msg = r"The stratification parameters '\['nc'\]' indicates a stratification size of \[2\], but"
     with pytest.raises(ValueError, match=msg):
         SIRstratified(initial_states2, parameters)
 
@@ -179,15 +179,15 @@ def test_model_stratified_init_validation():
         SIRstratified(initial_states, parameters)
 
     SIRstratified.parameter_names = ["gamma"]
-    SIRstratified.parameters_stratified_names = ["beta", "alpha"]
+    SIRstratified.parameters_stratified_names = [["beta", "alpha"]]
     with pytest.raises(ValueError, match=msg):
         SIRstratified(initial_states, parameters)
 
     # ensure to set back to correct ones
     SIRstratified.state_names = ["S", "I", "R"]
     SIRstratified.parameter_names = ["gamma"]
-    SIRstratified.parameters_stratified_names = ["beta"]
-    SIRstratified.stratification = "nc"
+    SIRstratified.parameters_stratified_names = [["beta"]]
+    SIRstratified.stratification = ["nc"]
 
 
 def test_model_stratified_default_initial_state():


### PR DESCRIPTION
The tests should now be passing:

- Fixed the base model code to again work for the simple case without stratification
- Fixed the stratified test model to use `stratification == ['nc']` instead of `stratification == 'nc'` (a list is now required even for a single stratitification after https://github.com/UGentBiomath/COVID19-Model/pull/149)
- Fixed the validation of the time dependent parameters
